### PR TITLE
Checks for the function to respond to HTTP events only, updates the …

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,7 @@ function addAuthorizerFunctionToPrivateFunctions(serverless) {
     // also doesn't have a custom authorizer already, apply our authenticator
     for(let fnctn_event in fnctn['events']) {
       if(
+        serverless.service.functions[function_name].events[fnctn_event].http != null &&
         serverless.service.functions[function_name].events[fnctn_event].http.private == true &&
         serverless.service.functions[function_name].events[fnctn_event].http.authorizer == null
       ) {

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ provider:
     - platypus
 ```
 
-For each function which is marked as `private: true`, the custom authenticator will be inserted, like so:
+For each function that responds to `http` events and is marked as `private: true`, the custom authenticator will be inserted, like so:
 
 ```
 functions:


### PR DESCRIPTION
…docs to advertise this feature

Why
---

* Currently the only function types that support the `private` keyword are ones that respond to http events.

How
---

* The former conditional logic for non-http event types for example, dynamo, s3, and iot causes an error because it assumes http exists and is non-null
* Check that the function responses to http events, only apply the authenticator to those functions